### PR TITLE
Add associate access, update user_dict, added time check for guests

### DIFF
--- a/OLYMPUS.py
+++ b/OLYMPUS.py
@@ -253,8 +253,8 @@ def main():
         time.sleep(.1)
 
         card_uid = Read_MFRC522.Read_UID()
-        logger.debug(f"{card_uid=}")	
-        
+        logger.debug(f"{card_uid=}")
+
         switch, button = Get_Buttons.read()
         
         clearence = look_up_clearance_level(card_uid, user_dict)
@@ -282,7 +282,14 @@ def main():
         if card_uid and is_valid and not switch:
             print(switch, button)
             logger.info(f"{switch=} {button=}")
-            strike_the_door()
+
+            hour_now = datetime.hour
+            if (clearence == level_1) and (hour_now > 10) and (hour_now < 22)
+                strike_the_door()
+            elif (clearence == level_1) and (hour_now < 10) and (hour_now > 22)
+                Pi_to_OLED.New_Message("You are outside of access hours")
+            else:
+                strike_the_door()
             send_log(("Opened door to "+card_uid+" at "+str(datetime.now())))
         
         elif card_uid and is_valid and (switch == True) and ((clearence == level_2) or (clearence == level_3) or (clearence == level_99)):

--- a/OLYMPUS.py
+++ b/OLYMPUS.py
@@ -161,7 +161,7 @@ def add_uid(mentor_UID, new_UID, mentor_clearance_level, prodigy_clearance_level
                 'mentor': mentor_UID
             }
         elif (prodigy_clearance_level == level_2) and (mentor_clearance_level == level_3) or (mentor_clearance_level == level_99):
-            # associate - daily time limit (not created yet)
+            # associate - can only add guests, no expiration
             new_tag_data = {
                 'clearance': prodigy_clearance_level,  # Replace with your actual tag ID
                 'expire_date': 0,

--- a/Update_User_Dict.py
+++ b/Update_User_Dict.py
@@ -1,45 +1,16 @@
 import OLYMPUS
 
-def add_access_hours_to_user_data(user_dict):
+user_dict = OLYMPUS.load_json()
+
+def update_clearance_level(user_dict):
     for uid, user_info in user_dict.items():
-        if 'access_hours' not in user_info:
-            # If access_hours field is missing, add it
-            if 'clearance' in user_info:
-                clearance = user_info['clearance']
-                if clearance == 'level 1':
-                    user_info['access_hours'] = '9 AM - 5 PM'
-                elif clearance == 'level 2':
-                    user_info['access_hours'] = '8 AM - 6 PM'
-                elif clearance == 'level 3':
-                    user_info['access_hours'] = '7 AM - 7 PM'
-                else:
-                    user_info['access_hours'] = 'Unknown'
-            else:
-                user_info['access_hours'] = 'Unknown'
+        if 'clearance' in user_info:
+            clearance = user_info['clearance']
+            if clearance == 'level_2':
+                user_info['clearance'] = 'level_3'
+            elif clearance == 'level_3':
+                user_info['clearance'] = 'level_99'
 
-# Example usage:
-user_dict = {
-    'user1': {
-        'name': 'John',
-        'age': 30,
-    },
-    'user2': {
-        'name': 'Alice',
-        'age': 25,
-        'access_hours': '9 AM - 5 PM',
-    },
-    'user3': {
-        'name': 'Bob',
-        'age': 35,
-    }
-}
-
-add_access_hours_to_user_data(user_dict)
+update_clearance_level(user_dict)
 OLYMPUS.rewrite_user_dict(user_dict)
-
-# Print updated user_dict
-for uid, user_info in user_dict.items():
-    print(f'UID: {uid}')
-    print(f'User Data: {user_info}')
-    print()
 

--- a/Update_User_Dict.py
+++ b/Update_User_Dict.py
@@ -1,0 +1,45 @@
+import OLYMPUS
+
+def add_access_hours_to_user_data(user_dict):
+    for uid, user_info in user_dict.items():
+        if 'access_hours' not in user_info:
+            # If access_hours field is missing, add it
+            if 'clearance' in user_info:
+                clearance = user_info['clearance']
+                if clearance == 'level 1':
+                    user_info['access_hours'] = '9 AM - 5 PM'
+                elif clearance == 'level 2':
+                    user_info['access_hours'] = '8 AM - 6 PM'
+                elif clearance == 'level 3':
+                    user_info['access_hours'] = '7 AM - 7 PM'
+                else:
+                    user_info['access_hours'] = 'Unknown'
+            else:
+                user_info['access_hours'] = 'Unknown'
+
+# Example usage:
+user_dict = {
+    'user1': {
+        'name': 'John',
+        'age': 30,
+    },
+    'user2': {
+        'name': 'Alice',
+        'age': 25,
+        'access_hours': '9 AM - 5 PM',
+    },
+    'user3': {
+        'name': 'Bob',
+        'age': 35,
+    }
+}
+
+add_access_hours_to_user_data(user_dict)
+OLYMPUS.rewrite_user_dict(user_dict)
+
+# Print updated user_dict
+for uid, user_info in user_dict.items():
+    print(f'UID: {uid}')
+    print(f'User Data: {user_info}')
+    print()
+


### PR DESCRIPTION
- Added Update_User_Dict.py to updated existing offline_json.json to new schema.
- Added a time check for guest access for 10am to 10pm, otherwise entry will be denied.
- Added a new switch/button condition for when adding new members to account for the new access level. To add guests you now flip down switch, do nothing for associates, and hold button for members.
- Updated some logging / ui messages
- Updated clearance levels to be Guest 1, Associate 2, Member 3, God 99. Permissions are:
  - Guest - 30 day access / daily time limit
  - Associate - unlimited access, can only add guests
  - Member -unlimited access, can add guests, associates, or members
  - God - almighty powers
- Added comments for where to call Doorbot script

